### PR TITLE
[fix] README: table format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Software Engineering
 
 |         | Paper           |
-| ---- | ------------- | ---------------------  |
+| ---- | ------------- |
 | :white_medium_square: | [SOFTWARE ENGINEERING - Report on a conference sponsored by the NATO SCIENCE COMMITTEE](http://homepages.cs.ncl.ac.uk/brian.randell/NATO/nato1968.PDF) |
 
 
@@ -9,7 +9,7 @@
 
 ## Essence
 |         | Paper           |
-| ---- | ------------- | ---------------------  |
+| ---- | ------------- |
 | :white_medium_square: | [Can Programming Be Liberated from the von Neumann Style? A Functional Style and Its Algebra of Programs](https://www.cs.cmu.edu/~crary/819-f09/Backus78.pdf) |
 | :white_square_button: | [Why Functional Programming Matters by J. Hughes](http://comjnl.oxfordjournals.org/content/32/2/98.full.pdf) |
 | :white_medium_square: | [The essence of functional programming  by Philip Wadler](https://wiki.ittc.ku.edu/lambda/images/1/12/Wadler_-_The_essence_of_functional_programming_(1992).pdf) |
@@ -18,7 +18,7 @@
 ## A bit of history
 
 |         | Paper           |
-| ---- | ------------- | ---------------------  |
+| ---- | ------------- |
 | :white_medium_square: | [Some History of Functional Programming Languages by D. A. Turner](https://www.cs.kent.ac.uk/people/staff/dat/tfp12/tfp12.pdf) |
 | :white_medium_square: | [The Conception, Evolution, and Application of Functional Programming Languages by Paul Hudak](http://haskell.cs.yale.edu/wp-content/uploads/2011/01/cs.pdf) |
 | :white_medium_square: | [History of Lambda-calculus and Combinatory Logic by Felice Cardone and J. Roger Hindley](http://www.users.waitrose.com/~hindley/SomePapers_PDFs/2006CarHin,HistlamRp.pdf) |
@@ -27,14 +27,14 @@
 ## Strong Functional Programming
 
 |         | Paper           |
-| ---- | ------------- | ---------------------  |
+| ---- | ------------- |
 | :white_medium_square: | [Elementary Strong Functional Programming by D. A. Turner](https://www.cs.kent.ac.uk/people/staff/dat/esfp/fple.pdf) |
 | :white_medium_square: | [A Tutorial Implementation of a Dependently Typed Lambda Calculus](http://www.andres-loeh.de/LambdaPi/) |
  
 ## Monads, monads everywhere
 
 |         | Paper           |
-| ---- | ------------- | ---------------------  |
+| ---- | ------------- |
 | :white_medium_square: | [Monads for functional programming by Philip Wadler](http://homepages.inf.ed.ac.uk/wadler/papers/marktoberdorf/baastad.pdf) |
 | :white_medium_square: | [Monad Transformers Step by Step](http://www.cs.virginia.edu/~wh5a/personal/Transformers.pdf) |
 
@@ -42,7 +42,7 @@
 ## Recursion schemas
  
 |         | Paper           |
-| ---- | ------------- | ---------------------  |
+| ---- | ------------- |
 | :white_medium_square: | [Recursion Schemas from Comonads by Tarmo Uustalu](http://cs.ioc.ee/~tarmo/papers/nwpt00-njc.pdf) |
 | :white_medium_square: | [Unifying Structured Recursion Schemes by Ralf Hinze, Nicolas Wu and Jeremy Gibbons](http://www.cs.ox.ac.uk/people/jeremy.gibbons/publications/urs.pdf) |
 | :white_medium_square: | [Functional Programming with Bananas, Lenses, Envelopes and Barbed Wire by Erik Meijer Maarten, Fokkinga and Ross Paterson](http://eprints.eemcs.utwente.nl/7281/01/db-utwente-40501F46.pdf) |
@@ -50,7 +50,7 @@
 ## Other
 
 |         | Paper           |
-| ---- | ------------- | ---------------------  |
+| ---- | ------------- |
 | :white_medium_square: | [Purely Functional Data Structures by Chris Okasaki](https://www.cs.cmu.edu/~rwh/theses/okasaki.pdf) |
 | :white_medium_square: | [Program Design by Calculation by J.N.Oliveira (draft)](http://www4.di.uminho.pt/~jno/ps/pdbc.pdf) |
 | :white_medium_square: | [Adaptive Lock-Free Maps: Purely-Functional to Scalable by Ryan R. Newton Peter P. Fogg Ali Varamesh](http://dl.acm.org/citation.cfm?id=2784734111) |
@@ -70,7 +70,7 @@
 
 # JVM
 |         | Paper           |
-| ---- | ------------- | ---------------------  |
+| ---- | ------------- |
 | :white_medium_square: | [Comparison of Erlang Runtime System and Java Virtual Machine](http://ds.cs.ut.ee/courses/course-files/To303nis%20Pool%20.pdf) |
 
 # Other

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 
 # Haskell
 |         | Paper           |
-| ---- | ------------- | ---------------------  |
+| ---- | ------------- |
 | :white_medium_square: | [A Gentle Introduction to Haskell by Paul Hudak, John Peterson and Joseph Fasel](https://www.haskell.org/tutorial/haskell-98-tutorial.pdf) |
 | :white_medium_square: | [A History of Haskell: Being Lazy With Class](http://haskell.cs.yale.edu/wp-content/uploads/2011/02/history.pdf) |
 


### PR DESCRIPTION
Fix table format in README.md following GitHub's markdown update.

__Before__:

|         | Paper           |
| ---- | ------------- | ---------------------  |
 | :white_medium_square: | [SOFTWARE ENGINEERING - Report on a conference sponsored by the NATO SCIENCE COMMITTEE](http://homepages.cs.ncl.ac.uk/brian.randell/NATO/nato1968.PDF) |

__After__:

|         | Paper           |
| ---- | ------------- |
 | :white_medium_square: | [SOFTWARE ENGINEERING - Report on a conference sponsored by the NATO SCIENCE COMMITTEE](http://homepages.cs.ncl.ac.uk/brian.randell/NATO/nato1968.PDF) |